### PR TITLE
Export for Windows, use cargo ws to publish crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,8 @@ jobs:
           # - os: macos-11
           #   target: aarch64-apple-darwin
 
-          ## TODO: need to fix windows bugs before building for windows.
-          # - os: windows-2019
-          #   target: x86_64-pc-windows-msvc
-          # - os: windows-2019
-          #   target: aarch64-pc-windows-msvc
+          - os: windows-2022
+            target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -78,7 +75,8 @@ jobs:
         with:
           files: |
             x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu.zip
-            x86_64-apple-darwin/x86_64-apple-darwin.zip   
+            x86_64-apple-darwin/x86_64-apple-darwin.zip
+            x86_64-pc-windows-msvc/x86_64-pc-windows-msvc.zip
 
   publish-extension:
     needs: publish-release
@@ -97,16 +95,12 @@ jobs:
       - run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
       - uses: actions-rs/cargo@v1
         with:
-          command: publish
-          args: -p flowistry
-      # Sleep is b/c flowistry_ide won't publish until flowistry
-      # has registered on crates.io which takes a second. 
-      # TODO: is there a better way to wait?
-      - run: sleep 60; cp README.md crates/flowistry_ide/
+          command: install
+          args: cargo-workspaces
       - uses: actions-rs/cargo@v1
         with:
-          command: publish
-          args: -p flowistry_ide --allow-dirty
+          command: ws
+          args: publish --from-git --yes
 
   publish-docs:
     needs: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flowistry"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "flowistry_ide"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "flowistry_ifc"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "flowistry_ifc_traits"
-version = "0.5.17"
+version = "0.5.18"
 
 [[package]]
 name = "fluid-let"


### PR DESCRIPTION
This PR would re-enable Windows support. I can't reproduce #27 on modern builds of Flowistry, and the codebase has been significantly rewritten since then, so I think it's best to just re-enable it until the issue crops up again.

Also, we can use `cargo ws` to publish crates instead of having to awkwardly sleep for a minute and assume crates.io is done processing by then. Unfortunately there's no real way to test whether this works without just pushing a release and hoping for the best. I've checked through the documentation a few times to make sure that the intended semantics are there, but I can't guarantee that it'll work first try.