### PR TITLE
Fix bench results not saving in `gh-pages` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,9 @@ jobs:
       - uses: actions/checkout@v1
       - run: cargo doc --lib
       - run: RUSTDOCFLAGS="--html-in-header scripts/katex-header.html" cargo doc --lib --no-deps
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: JamesIves/github-pages-deploy-action@v4.3.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc
+          branch: gh-pages
+          folder: ./target/doc
+          clean: true
+          clean-exclude: dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,5 +42,4 @@ jobs:
           tool: 'cargo'
           output-file-path: crates/flowistry/benches/output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: false
-          comment-always: true
+          auto-push: true


### PR DESCRIPTION
This PR enables the `github-action-benchmark` action to save and deploy bench results to the `gh-pages` branch. This was disabled to avoid conflicts/overwrites with the documentation files since the [current action](https://github.com/peaceiris/actions-gh-pages) cleans the directory on each new rebuild of the docs. The action has an option to [`keep_files`](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-keeping-existing-files-keep_files) but it doesn't allow us to specify which files to keep (in our case we only want to keep the bench data).

This is fixed by using a [new GH pages deployment action](https://github.com/JamesIves/github-pages-deploy-action) which has an option for keeping only specific files and cleaning the rest (see updated `release.yml`).

One minor thing - the bench data will be displayed at `https://willcrichton.net/flowistry/dev/bench`. AFAIK this would only cause an issue if flowistry adds a `dev` crate as a dependency but in that unlikely scenario we can just switch to another path.

You can also check out an example of the bench results [here](https://connorff.github.io/flowistry/dev/bench).