### PR TITLE
Fix terminal usage with VSCode plugin

### DIFF
--- a/ide/package.json
+++ b/ide/package.json
@@ -85,22 +85,26 @@
       {
         "command": "flowistry.focus",
         "key": "ctrl+r ctrl+a",
-        "mac": "meta+r meta+a"
+        "mac": "meta+r meta+a",
+        "when": "!terminalFocus"
       },
       {
         "command": "flowistry.focus_mark",
         "key": "ctrl+r ctrl+s",
-        "mac": "meta+r meta+s"
+        "mac": "meta+r meta+s",
+        "when": "!terminalFocus"
       },
       {
         "command": "flowistry.focus_unmark",
         "key": "ctrl+r ctrl+d",
-        "mac": "meta+r meta+d"
+        "mac": "meta+r meta+d",
+        "when": "!terminalFocus"
       },
       {
         "command": "flowistry.focus_select",
         "key": "ctrl+r ctrl+t",
-        "mac": "meta+r meta+t"
+        "mac": "meta+r meta+t",
+        "when": "!terminalFocus"
       }
     ]
   },

--- a/ide/package.json
+++ b/ide/package.json
@@ -86,25 +86,25 @@
         "command": "flowistry.focus",
         "key": "ctrl+r ctrl+a",
         "mac": "meta+r meta+a",
-        "when": "!terminalFocus"
+        "when": "editorFocus"
       },
       {
         "command": "flowistry.focus_mark",
         "key": "ctrl+r ctrl+s",
         "mac": "meta+r meta+s",
-        "when": "!terminalFocus"
+        "when": "editorFocus"
       },
       {
         "command": "flowistry.focus_unmark",
         "key": "ctrl+r ctrl+d",
         "mac": "meta+r meta+d",
-        "when": "!terminalFocus"
+        "when": "editorFocus"
       },
       {
         "command": "flowistry.focus_select",
         "key": "ctrl+r ctrl+t",
         "mac": "meta+r meta+t",
-        "when": "!terminalFocus"
+        "when": "editorFocus"
       }
     ]
   },


### PR DESCRIPTION
The extension's keyboard shortcuts are now registered to only be active when the terminal is not focused, so Ctrl+R is still passed through the terminal for users who install the extension.

Fixes #61.