### PR TITLE
Problems with Loops

### DIFF
--- a/crates/flowistry/tests/pdg.rs
+++ b/crates/flowistry/tests/pdg.rs
@@ -471,6 +471,24 @@ pdg_test! {
   (x -> y)
 }
 
+pdg_test! {
+  loops,
+  {
+    fn main() {
+      let mut user_data = vec![];
+      while user_data.len() < 10 {
+        let user_data_ref = &mut user_data;
+        user_data_ref.push(0_u32);
+      }
+      let user_data_ref_2 = &mut user_data;
+      user_data_ref_2.remove(4);
+    }
+  },
+  (user_data -> user_data_ref),
+  (user_data_ref -> user_data_ref),
+  (user_data_ref -> user_data_ref_2)
+}
+
 #[test]
 fn call_filter() {
   let input = r#"


### PR DESCRIPTION
I found there to be issues with loops where the body of the loop is not connected to either the state before or after.

This PR provides a simple test case that illustrates the problem. 

The `user_data_ref` variable isn't even found in the PDG at all and I believe neither is the call to `push` (the latter I only verified in the virtually identical Paralegal test case where I could dump both the PDG and the MIR to check which location corresponded to the call).